### PR TITLE
Automatically show an address on wallet page; update it when used.

### DIFF
--- a/js/lbry.js
+++ b/js/lbry.js
@@ -7,6 +7,7 @@ var lbry = {
   },
   defaultClientSettings: {
     showNsfw: false,
+    walletPageAddress: "",
   }
 };
 

--- a/js/page/wallet.js
+++ b/js/page/wallet.js
@@ -4,12 +4,28 @@ var NewAddressSection = React.createClass({
       this.setState({
         address: results,
       })
+      lbry.setClientSetting("walletPageAddress", results)
     });
   },
   getInitialState: function() {
     return {
       address: "",
     }
+  },
+  componentWillMount: function() {
+    if (lbry.getClientSetting("walletPageAddress")=="") {
+      this.generateAddress();
+    }
+    lbry.call('get_transaction_history', {}, (results) => {
+      var oldAddr = lbry.getClientSetting("walletPageAddress");
+      if (results.indexOf(oldAddr) >= 0) {
+        this.generateAddress();
+      } else {
+        this.setState({
+          address: oldAddr,
+        });
+      }
+    });
   },
   render: function() {
     return (


### PR DESCRIPTION
This feature is affected by what appears to be an existing bug that I haven't yet pinned down, affecting persistence of settings.