### PR TITLE
Use search servers from daemon

### DIFF
--- a/js/lbry.js
+++ b/js/lbry.js
@@ -263,6 +263,11 @@ lbry.formatName = function(name) {
   return name.toLowerCase().replace(/[^a-z0-9\-]/, '');
 }
 
+// Get a randomly chosen item from a collection
+lbry.choice = function(collection) {
+  return collection[Math.round(Math.random() * (collection.length - 1))];
+}
+
 lbry.loadJs = function(src, type, onload)
 {
   var lbryScriptTag = document.getElementById('lbry'),

--- a/js/lbry.js
+++ b/js/lbry.js
@@ -183,6 +183,10 @@ lbry.getVersionInfo = function(callback) {
   lbry.call('version', {}, callback);
 };
 
+lbry.getSearchServers = function(callback) {
+  lbry.call('get_search_servers', {}, callback);
+}
+
 lbry.checkNewVersionAvailable = function(callback) {
   lbry.call('version', {}, function(versionInfo) {
     var ver = versionInfo.lbrynet_version.split('.');

--- a/js/lighthouse.js
+++ b/js/lighthouse.js
@@ -1,9 +1,12 @@
 lbry.lighthouse = {
-  servers: [
+  // We get the list of search servers from the daemon, but this list is used as a default in case
+  // the daemon somehow fails to respond before the first time we query Lighthouse.
+  default_servers: [
     'http://lighthouse1.lbry.io:50005',
     'http://lighthouse2.lbry.io:50005',
     'http://lighthouse3.lbry.io:50005',
   ],
+  servers: null,
   path: '/',
 
   call: function(method, params, callback, errorCallback, connectFailedCallback) {
@@ -11,4 +14,7 @@ lbry.lighthouse = {
   },
 };
 
-lbry.lighthouse.server = lbry.lighthouse.servers[Math.round(Math.random() * (lbry.lighthouse.servers.length - 1))];
+lbry.lighthouse.server = lbry.choice(lbry.lighthouse.default_servers);
+lbry.getSearchServers(function(servers) {
+    lbry.lighthouse.server = lbry.choice(servers);
+});


### PR DESCRIPTION
Asks the daemon for the list of Lighthouse servers. Useful for debugging. Falls back on a default list if the daemon fails to respond.