### PR TITLE
Make Publish process snappier and more informative (WIP)

### DIFF
--- a/js/lbry.js
+++ b/js/lbry.js
@@ -169,14 +169,42 @@ lbry.revealFile = function(path, callback) {
   lbry.call('reveal', { path: path }, callback);
 }
 
-lbry.publish = function(params, callback, errorCallback) {
+lbry.getFileInfoWhenListed = function(name, callback, timeoutCallback, tryNum=0) {
+  // Calls callback with file info when it appears in the list of files returned by lbry.getFilesInfo().
+  // If timeoutCallback is provided, it will be called if the file fails to appear.
+  lbry.getFilesInfo(function(filesInfo) {
+    for (var fileInfo of filesInfo) {
+      if (fileInfo.lbry_uri == name) {
+        callback(fileInfo);
+        return;
+      }
+    }
+
+    if (tryNum <= 200) {
+      setTimeout(function() { lbry.getFileInfoWhenListed(name, callback, timeoutCallback, tryNum + 1) }, 250);
+    } else if (timeoutCallback) {
+      timeoutCallback();
+    }
+  });
+}
+
+lbry.publish = function(params, fileListedCallback, publishedCallback, errorCallback) {
+  // Publishes a file.
+  // The optional fileListedCallback is called when the file becomes available in
+  // lbry.getFilesInfo() during the publish process.
+
   // Use ES6 named arguments instead of directly passing param dict?
-  lbry.call('publish', params, callback, (errorInfo) => {
+  lbry.call('publish', params, publishedCallback, (errorInfo) => {
     errorCallback({
       name: fault.fault,
       message: fault.faultString,
     });
   });
+  if (fileListedCallback) {
+    lbry.getFileInfoWhenListed(params.name, function(fileInfo) {
+      fileListedCallback(fileInfo);
+    });
+  }
 }
 
 lbry.getVersionInfo = function(callback) {

--- a/js/page/my_files.js
+++ b/js/page/my_files.js
@@ -110,7 +110,7 @@ var MyFilesRow = React.createClass({
                  {this.props.completed ? 'Download complete' : (parseInt(this.props.ratioLoaded * 100) + '%')}
                  <div>{ pauseLink }</div>
                  <div>{ watchButton }</div>
-                 {this.props.available ? null : <p><em>This file is now uploading to Reflector. This service hosts a copy of the file on LBRY's servers so that it's available even if no one with the file is online.</em></p>}
+                 {this.props.available ? null : <p><em>This file is uploading to Reflector. Reflector is a service that hosts a copy of the file on LBRY's servers so that it's available even if no one with the file is online.</em></p>}
                </div>
              )
             }

--- a/js/page/publish.js
+++ b/js/page/publish.js
@@ -86,11 +86,11 @@ var PublishPage = React.createClass({
 
       console.log(publishArgs);
       lbry.publish(publishArgs, (message) => {
-        this.handlePublishSuccess();
+        this.handlePublishStarted();
         this.setState({
           submitting: false,
         });
-      }, (error) => {
+      }, null, (error) => {
         this.handlePublishError(error);
         this.setState({
           submitting: false,
@@ -131,7 +131,7 @@ var PublishPage = React.createClass({
       submitting: false,
     };
   },
-  handlePublishSuccess: function() {
+  handlePublishStarted: function() {
     alert(`Your file ${this.refs.meta_title.getValue()} has been published to LBRY at the address lbry://${this.state.name}!\n\n` +
           `You will now be taken to your My Files page, where your newly published file will be listed. Your file will take a few minutes to appear for other LBRY users; until then it will be listed as "pending."`);
     window.location = "?files";


### PR DESCRIPTION
- Make the Publish page send the user to the My Files screen as soon as the publication process starts, instead of when the file is already published and waiting for confirmation
- On My Files, add a message when the file is published but still uploading to Lighthouse (the formatting of this will change, maybe even an icon with tooltip instead of a message)

To do: Add a separate message for when the file is processing but not yet waiting for confirmation, and possibly for other stages. It may even be possible to do a progress bar.