### PR TITLE
basic electron app

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -1,0 +1,49 @@
+const {app, BrowserWindow} = require('electron')
+
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the JavaScript object is garbage collected.
+let win
+
+function createWindow () {
+  // Create the browser window.
+  win = new BrowserWindow({width: 800, height: 600})
+
+  // and load the index.html of the app.
+  win.loadURL('http://localhost:5279')
+
+  // Open the DevTools.
+  win.webContents.openDevTools()
+
+  // Emitted when the window is closed.
+  win.on('closed', () => {
+    // Dereference the window object, usually you would store windows
+    // in an array if your app supports multi windows, this is the time
+    // when you should delete the corresponding element.
+    win = null
+  })
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.on('ready', createWindow)
+
+// Quit when all windows are closed.
+app.on('window-all-closed', () => {
+  // On macOS it is common for applications and their menu bar
+  // to stay active until the user quits explicitly with Cmd + Q
+  if (process.platform !== 'darwin') {
+    app.quit()
+  }
+})
+
+app.on('activate', () => {
+  // On macOS it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  if (win === null) {
+    createWindow()
+  }
+})
+
+// In this file you can include the rest of your app's specific main process
+// code. You can also put them in separate files and require them here.

--- a/dist/main.js
+++ b/dist/main.js
@@ -9,7 +9,7 @@ function createWindow () {
   win = new BrowserWindow({width: 800, height: 600})
 
   // and load the index.html of the app.
-  win.loadURL('http://localhost:5279')
+  win.loadURL(`file://${__dirname}/index.html`)
 
   // Open the DevTools.
   win.webContents.openDevTools()

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,0 +1,5 @@
+{
+  "name"    : "your-app",
+  "version" : "0.1.0",
+  "main"    : "../dist/main.js"
+}

--- a/js/app.js
+++ b/js/app.js
@@ -83,17 +83,17 @@ var App = React.createClass({
       case 'claim':
       case 'referral':
         return {
-          '?wallet' : 'Overview',
-          '?send' : 'Send',
-          '?receive' : 'Receive',
-          '?claim' : 'Claim Beta Code',
-          '?referral' : 'Check Referral Credit',
+          'index.html?wallet' : 'Overview',
+          'index.html?send' : 'Send',
+          'index.html?receive' : 'Receive',
+          'index.html?claim' : 'Claim Beta Code',
+          'index.html?referral' : 'Check Referral Credit',
         };
       case 'downloaded':
       case 'published':
         return {
-          '?downloaded': 'Downloaded',
-          '?published': 'Published',
+          'index.html?downloaded': 'Downloaded',
+          'index.html?published': 'Published',
         };
       default:
         return null;


### PR DESCRIPTION
Copy/paste the starting code from http://electron.atom.io/docs/tutorial/quick-start/

Can launch app by running `electron electron` from the root directory.  The daemon needs to be already running first, of course.

This is not something that should be merged in, but I mostly wanted to see how much work was needed to get the simplest thing working.