### PR TITLE
Revert "only deploy on a tag"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ deploy:
   upload-dir: ${TRAVIS_BRANCH}
   local_dir: upload
   on:
-    tags: true
+    all_branches: true


### PR DESCRIPTION
Reverts lbryio/lbry-web-ui#66

Because of https://github.com/travis-ci/travis-ci/issues/1670, using tags doesn't work with the current release process for the web-ui.  Need to rework!