### PR TITLE
Refactor My Files page (WIP)

### DIFF
--- a/js/lbry.js
+++ b/js/lbry.js
@@ -242,6 +242,10 @@ lbry.getFilesInfo = function(callback) {
   lbry.call('get_lbry_files', {}, callback);
 }
 
+lbry.getMyClaims = function(callback) {
+  lbry.call('get_name_claims', {}, callback);
+}
+
 lbry.startFile = function(name, callback) {
   lbry.call('start_lbry_file', { name: name }, callback);
 }

--- a/js/lbry.js
+++ b/js/lbry.js
@@ -242,6 +242,18 @@ lbry.getFilesInfo = function(callback) {
   lbry.call('get_lbry_files', {}, callback);
 }
 
+lbry.getFileInfoByName = function(name, callback) {
+  lbry.call('get_lbry_file', {name: name}, callback);
+}
+
+lbry.getFileInfoBySdHash = function(sdHash, callback) {
+  lbry.call('get_lbry_file', {sd_hash: sdHash}, callback);
+}
+
+lbry.getFileInfoByFilename = function(filename, callback) {
+  lbry.call('get_lbry_file', {file_name: filename}, callback);
+}
+
 lbry.getMyClaims = function(callback) {
   lbry.call('get_name_claims', {}, callback);
 }

--- a/js/page/my_files.js
+++ b/js/page/my_files.js
@@ -268,10 +268,14 @@ var MyFilesPage = React.createClass({
           <BusyMessage message="Loading" />
         </main>
       );
-    }
-
-    if (!this.state.filesInfo.length) {
-      var content = <span>You haven't downloaded anything from LBRY yet. Go <Link href="/" label="search for your first download" />!</span>;
+    } else if (!this.state.filesInfo.length) {
+      return (
+        <main className="page">
+          {this.props.show == 'downloaded'
+            ? <span>You haven't downloaded anything from LBRY yet. Go <Link href="/" label="search for your first download" />!</span>
+            : <span>You haven't published anything to LBRY yet.</span>}
+        </main>
+      );
     } else {
       var content = [],
           seenUris = {};


### PR DESCRIPTION
This PR heavily refactors the My Files page. The main change is that the "Published" and "Downloaded" pages now use separate logic to generate their lists of files.

 - Published page now looks up the user's claims instead of files. This allows published streams to be listed even if the files don't exist on the user's machine; also, because it looks up file info by txid, you will no longer see a newer claim listed if you made a claim and it was overtaken.
 - Downloaded page works pretty much the same as before
 - Checking for file ownership is now done by making one call to lbry.getMyClaims() and saving a list of txids of streams published by the user. Before, it was making a call to lbry.getFilesInfo() and checking ownership on each one, which was way slower.
 - Also added a message to the Publish page when there are no files published yet (before, it was using the same message as the Downloaded page)