### PR TITLE
Fix issues with display of bids on Publish page

### DIFF
--- a/js/page/publish.js
+++ b/js/page/publish.js
@@ -337,7 +337,7 @@ var PublishPage = React.createClass({
                 (!this.state.name ? '' :
                   (! this.state.nameResolved ? <em> The name <strong>{this.state.name}</strong> is available.</em>
                                              : (this.state.myClaimExists ? <em> You already have a claim on the name <strong>{this.state.name}</strong>. You can use this page to update your claim.</em>
-                                                                         : <em> The name <strong>{this.state.name}</strong> is currently claimed for <strong>{lbry.formatCredits(this.state.topClaimValue)}</strong> credits.</em>)))
+                                                                         : <em> The name <strong>{this.state.name}</strong> is currently claimed for <strong>{this.state.topClaimValue}</strong> credits.</em>)))
               }
               <div className="help">What LBRY name would you like to claim for this file?</div>
             </div>
@@ -358,13 +358,13 @@ var PublishPage = React.createClass({
           <section className="card">
             <h4>Bid Amount</h4>
             <div className="form-row">
-              Credits <FormField ref="bid" style={publishNumberStyle} type="text" onChange={this.handleBidChange} value={this.state.bid} placeholder={this.state.nameResolved ? lbry.formatCredits(this.state.topClaimValue + 10) : 100} />
+              Credits <FormField ref="bid" style={publishNumberStyle} type="text" onChange={this.handleBidChange} value={this.state.bid} placeholder={this.state.nameResolved ? this.state.topClaimValue + 10 : 100} />
               <div className="help">How much would you like to bid for this name?
               { !this.state.nameResolved ? <span> Since this name is not currently resolved, you may bid as low as you want, but higher bids help prevent others from claiming your name.</span>
-                                         : (this.state.topClaimIsMine ? <span> You currently control this name with a bid of <strong>{lbry.formatCredits(this.state.myClaimValue)}</strong> credits.</span>
-                                                                      : (this.state.myClaimExists ? <span> You have a non-winning bid on this name for <strong>{lbry.formatCredits(this.state.myClaimValue)}</strong> credits.
-                                                                                                           To control this name, you'll need to increase your bid to at least <strong>{lbry.formatCredits(this.state.myClaimValue)}</strong> credits.</span>
-                                                                                                  : <span> You must bid over <strong>{lbry.formatCredits(this.state.topClaimValue)}</strong> credits to claim this name.</span>)) }
+                                         : (this.state.topClaimIsMine ? <span> You currently control this name with a bid of <strong>{this.state.myClaimValue}</strong> credits.</span>
+                                                                      : (this.state.myClaimExists ? <span> You have a non-winning bid on this name for <strong>{this.state.myClaimValue}</strong> credits.
+                                                                                                           To control this name, you'll need to increase your bid to at least <strong>{this.state.myClaimValue}</strong> credits.</span>
+                                                                                                  : <span> You must bid over <strong>{this.state.topClaimValue}</strong> credits to claim this name.</span>)) }
               </div>
             </div>
           </section>

--- a/js/page/publish.js
+++ b/js/page/publish.js
@@ -337,7 +337,7 @@ var PublishPage = React.createClass({
                 (!this.state.name ? '' :
                   (! this.state.nameResolved ? <em> The name <strong>{this.state.name}</strong> is available.</em>
                                              : (this.state.myClaimExists ? <em> You already have a claim on the name <strong>{this.state.name}</strong>. You can use this page to update your claim.</em>
-                                                                         : <em> The name <strong>{this.state.name}</strong> is currently claimed for <strong>{this.state.topClaimValue}</strong> credits.</em>)))
+                                                                         : <em> The name <strong>{this.state.name}</strong> is currently claimed for <strong>{this.state.topClaimValue}</strong> {this.state.topClaimValue == 1 ? 'credit' : 'credits'}.</em>)))
               }
               <div className="help">What LBRY name would you like to claim for this file?</div>
             </div>
@@ -361,10 +361,10 @@ var PublishPage = React.createClass({
               Credits <FormField ref="bid" style={publishNumberStyle} type="text" onChange={this.handleBidChange} value={this.state.bid} placeholder={this.state.nameResolved ? this.state.topClaimValue + 10 : 100} />
               <div className="help">How much would you like to bid for this name?
               { !this.state.nameResolved ? <span> Since this name is not currently resolved, you may bid as low as you want, but higher bids help prevent others from claiming your name.</span>
-                                         : (this.state.topClaimIsMine ? <span> You currently control this name with a bid of <strong>{this.state.myClaimValue}</strong> credits.</span>
-                                                                      : (this.state.myClaimExists ? <span> You have a non-winning bid on this name for <strong>{this.state.myClaimValue}</strong> credits.
-                                                                                                           To control this name, you'll need to increase your bid to more than <strong>{this.state.topClaimValue}</strong> credits.</span>
-                                                                                                  : <span> You must bid over <strong>{this.state.topClaimValue}</strong> credits to claim this name.</span>)) }
+                                         : (this.state.topClaimIsMine ? <span> You currently control this name with a bid of <strong>{this.state.myClaimValue}</strong> {this.state.myClaimValue == 1 ? 'credit' : 'credits'}.</span>
+                                                                      : (this.state.myClaimExists ? <span> You have a non-winning bid on this name for <strong>{this.state.myClaimValue}</strong> {this.state.myClaimValue == 1 ? 'credit' : 'credits'}.
+                                                                                                           To control this name, you'll need to increase your bid to more than <strong>{this.state.topClaimValue}</strong> {this.state.topClaimValue == 1 ? 'credit' : 'credits'}.</span>
+                                                                                                  : <span> You must bid over <strong>{this.state.topClaimValue}</strong> {this.state.topClaimValue == 1 ? 'credit' : 'credits'} to claim this name.</span>)) }
               </div>
             </div>
           </section>

--- a/js/page/publish.js
+++ b/js/page/publish.js
@@ -363,7 +363,7 @@ var PublishPage = React.createClass({
               { !this.state.nameResolved ? <span> Since this name is not currently resolved, you may bid as low as you want, but higher bids help prevent others from claiming your name.</span>
                                          : (this.state.topClaimIsMine ? <span> You currently control this name with a bid of <strong>{this.state.myClaimValue}</strong> credits.</span>
                                                                       : (this.state.myClaimExists ? <span> You have a non-winning bid on this name for <strong>{this.state.myClaimValue}</strong> credits.
-                                                                                                           To control this name, you'll need to increase your bid to at least <strong>{this.state.myClaimValue}</strong> credits.</span>
+                                                                                                           To control this name, you'll need to increase your bid to more than <strong>{this.state.topClaimValue}</strong> credits.</span>
                                                                                                   : <span> You must bid over <strong>{this.state.topClaimValue}</strong> credits to claim this name.</span>)) }
               </div>
             </div>


### PR DESCRIPTION
Fix issues with display of bids on Publish page

 - Display exact amounts for bids (was using lbry.formatCredits before, so bids lower than than 0.1 credits were displaying as 0.0)
 - Correctly pluralize "credit" vs. "credits" for bid amounts
 - Display top bid correctly (before, it would sometimes show the user's bid instead) 
 - Wording tweak: it said you must bid "at least ___ credits" to outbid an existing claim, now says "more than ___ credits"

Resolves this issue: https://app.asana.com/0/198587529699250/204870560230668