### PR TITLE
Highlight drawer item for sub-pages

### DIFF
--- a/js/component/drawer.js
+++ b/js/component/drawer.js
@@ -1,6 +1,12 @@
 var DrawerItem = React.createClass({
+  getDefaultProps: function() {
+    return {
+      subPages: [],
+    };
+  },
   render: function() {
-    var isSelected = this.props.viewingPage == this.props.href.substr(2);
+    var isSelected = (this.props.viewingPage == this.props.href.substr(2) ||
+                      this.props.subPages.indexOf(this.props.viewingPage) != -1);
     return <Link {...this.props} className={ 'drawer-item ' + (isSelected ? 'drawer-item-selected' : '') } />
   }
 });
@@ -32,8 +38,8 @@ var Drawer = React.createClass({
         </div>
         <DrawerItem href='/?discover' viewingPage={this.props.viewingPage} label="Discover" icon="icon-search"  />
         <DrawerItem href='/?publish' viewingPage={this.props.viewingPage} label="Publish" icon="icon-upload" />
-        <DrawerItem href='/?downloaded' viewingPage={this.props.viewingPage}  label="My Files" icon='icon-cloud-download' />
-        <DrawerItem href="/?wallet" viewingPage={this.props.viewingPage}  label="My Wallet" badge={lbry.formatCredits(this.state.balance) } icon="icon-bank" />
+        <DrawerItem href='/?downloaded' subPages={['published']} viewingPage={this.props.viewingPage}  label="My Files" icon='icon-cloud-download' />
+        <DrawerItem href="/?wallet" subPages={['send', 'receive', 'claim', 'referral']} viewingPage={this.props.viewingPage}  label="My Wallet" badge={lbry.formatCredits(this.state.balance) } icon="icon-bank" />
         <DrawerItem href='/?settings' viewingPage={this.props.viewingPage}  label="Settings" icon='icon-gear' />
         <DrawerItem href='/?help' viewingPage={this.props.viewingPage}  label="Help" icon='icon-question-circle' />
         {isLinux ? <Link href="/?start" icon="icon-close" className="close-lbry-link" /> : null}


### PR DESCRIPTION
Before, it was failing to highlight the drawer item when a different sub-tab was chosen (e.g. if you chose My Files and then go to Published, My Files would un-highlight in the drawer).

This solution feels kinda hacky--it might be better if we could somehow store the paths for the sub-pages in the App component, or even the individual page components. But AFAIK we're still planning to re-do the whole routing system at some point so I decided not to overthink it.

Resolves this issue: https://app.asana.com/0/search/211398218008538/207421714255316