### PR TITLE
formatName - replace spaces with dashes

### DIFF
--- a/js/lbry.js
+++ b/js/lbry.js
@@ -296,8 +296,10 @@ lbry.formatCredits = function(amount, precision)
 }
 
 lbry.formatName = function(name) {
-  // Converts LBRY name to standard format (all lower case, no special characters)
-  return name.toLowerCase().replace(/[^a-z0-9\-]/g, '');
+  // Converts LBRY name to standard format (all lower case, no special characters, spaces replaced by dashes)
+  name = name.replace(" ", "-");
+  name = name.toLowerCase().replace(/[^a-z0-9\-]/g, '');
+  return name;
 }
 
 lbry.loadJs = function(src, type, onload)

--- a/js/lbry.js
+++ b/js/lbry.js
@@ -297,7 +297,7 @@ lbry.formatCredits = function(amount, precision)
 
 lbry.formatName = function(name) {
   // Converts LBRY name to standard format (all lower case, no special characters, spaces replaced by dashes)
-  name = name.replace(" ", "-");
+  name = name.replace('/\s+/g', '-');
   name = name.toLowerCase().replace(/[^a-z0-9\-]/g, '');
   return name;
 }


### PR DESCRIPTION
Name-formatter now replaces spaces with dashes, for more readable names. This is similar to Wordpress' permalink processing.