### PR TITLE
Fix issue with live updating logic on Publish page

### DIFF
--- a/js/page/publish.js
+++ b/js/page/publish.js
@@ -164,6 +164,7 @@ var PublishPage = React.createClass({
         this.setState({
           name: name,
           nameResolved: false,
+          myClaimExists: false,
         });
       } else {
         lbry.getMyClaim(name, (myClaimInfo) => {


### PR DESCRIPTION
Previously, if the user typed a name that they have a claim on and then continued typing, some of the interface would not be updated to show that they don't have a claim.
