### PR TITLE
Improvements to Watch and Download links

### DIFF
--- a/js/component/link.js
+++ b/js/component/link.js
@@ -152,11 +152,15 @@ var WatchLink = React.createClass({
     hidden: React.PropTypes.bool,
   },
   handleClick: function() {
+    this.setState({
+      loading: true,
+    })
     lbry.getCostEstimate(this.props.streamName, (amount) => {
       lbry.getBalance((balance) => {
         if (amount > balance) {
           this.setState({
             modal: 'notEnoughCredits',
+            loading: false,
           });
         } else {
           window.location = '?watch=' + this.props.streamName;
@@ -167,6 +171,7 @@ var WatchLink = React.createClass({
   getInitialState: function() {
     return {
       modal: null,
+      loading: false,
     };
   },
   closeModal: function() {
@@ -184,7 +189,8 @@ var WatchLink = React.createClass({
     return (
       <span className="button-container">
         <Link button={this.props.button} hidden={this.props.hidden} style={this.props.style}
-                   label={this.props.label} icon={this.props.icon} onClick={this.handleClick} />
+              disabled={this.state.loading} label={this.props.label} icon={this.props.icon}
+              onClick={this.handleClick} />
         <Modal isOpen={this.state.modal == 'notEnoughCredits'} onConfirmed={this.closeModal}>
           You don't have enough LBRY credits to pay for this stream.
         </Modal>

--- a/js/component/link.js
+++ b/js/component/link.js
@@ -103,28 +103,26 @@ var DownloadLink = React.createClass({
     })
   },
   handleClick: function() {
-    lbry.getCostEstimate(this.props.streamName, (amount) => {
-      lbry.getBalance((balance) => {
-        if (amount > balance) {
-          this.setState({
-            modal: 'notEnoughCredits',
-          });
-        } else {
-          this.startDownload();
-        }
-      });
-    });
-  },
-  startDownload: function() {
     if (!this.state.downloading) { //@TODO: Continually update this.state.downloading based on actual status of file
       this.setState({
         downloading: true
       });
 
-      lbry.getStream(this.props.streamName, (streamInfo) => {
-        this.setState({
-          modal: 'downloadStarted',
-          filePath: streamInfo.path,
+      lbry.getCostEstimate(this.props.streamName, (amount) => {
+        lbry.getBalance((balance) => {
+          if (amount > balance) {
+            this.setState({
+              modal: 'notEnoughCredits',
+              downloading: false
+            });
+          } else {
+            lbry.getStream(this.props.streamName, (streamInfo) => {
+              this.setState({
+                modal: 'downloadStarted',
+                filePath: streamInfo.path,
+              });
+            });
+          }
         });
       });
     }

--- a/js/component/link.js
+++ b/js/component/link.js
@@ -116,10 +116,17 @@ var DownloadLink = React.createClass({
           });
         } else {
           lbry.getStream(this.props.streamName, (streamInfo) => {
-            this.setState({
-              modal: 'downloadStarted',
-              filePath: streamInfo.path,
-            });
+            if (typeof streamInfo !== 'object') {
+              this.setState({
+                modal: 'timedOut',
+                downloading: false,
+              });
+            } else {
+              this.setState({
+                modal: 'downloadStarted',
+                filePath: streamInfo.path,
+              });
+            }
           });
         }
       });
@@ -136,6 +143,9 @@ var DownloadLink = React.createClass({
         </Modal>
         <Modal isOpen={this.state.modal == 'notEnoughCredits'} onConfirmed={this.closeModal}>
           You don't have enough LBRY credits to pay for this stream.
+        </Modal>
+        <Modal isOpen={this.state.modal == 'timedOut'} onConfirmed={this.closeModal}>
+          LBRY was unable to download the stream <strong>lbry://{this.props.streamName}</strong>.
         </Modal>
       </span>
     );

--- a/js/component/link.js
+++ b/js/component/link.js
@@ -103,29 +103,27 @@ var DownloadLink = React.createClass({
     })
   },
   handleClick: function() {
-    if (!this.state.downloading) { //@TODO: Continually update this.state.downloading based on actual status of file
-      this.setState({
-        downloading: true
-      });
+    this.setState({
+      downloading: true
+    });
 
-      lbry.getCostEstimate(this.props.streamName, (amount) => {
-        lbry.getBalance((balance) => {
-          if (amount > balance) {
+    lbry.getCostEstimate(this.props.streamName, (amount) => {
+      lbry.getBalance((balance) => {
+        if (amount > balance) {
+          this.setState({
+            modal: 'notEnoughCredits',
+            downloading: false
+          });
+        } else {
+          lbry.getStream(this.props.streamName, (streamInfo) => {
             this.setState({
-              modal: 'notEnoughCredits',
-              downloading: false
+              modal: 'downloadStarted',
+              filePath: streamInfo.path,
             });
-          } else {
-            lbry.getStream(this.props.streamName, (streamInfo) => {
-              this.setState({
-                modal: 'downloadStarted',
-                filePath: streamInfo.path,
-              });
-            });
-          }
-        });
+          });
+        }
       });
-    }
+    });
   },
   render: function() {
     var label = (!this.state.downloading ? this.props.label : this.props.downloadingLabel);

--- a/js/component/modal.js
+++ b/js/component/modal.js
@@ -49,7 +49,9 @@ var Modal = React.createClass({
 
     return (
       <ReactModal {...props}>
-         {this.props.children}
+         <div>
+           {this.props.children}
+         </div>
          {buttons}
       </ReactModal>
     );


### PR DESCRIPTION
Download links:
- Switch to "Downloading" immediately on click (don't wait for balance check to finish)
- Don't bother to check this.state.downloading on click
- Properly notify the user when a download times out

Watch links:
- Disable on click so the user can tell something is happening during the balance check

All modals:
- Wrap contents of modals in div to prevent flexbox layout (was causing things to be laid out in their own line just because they were wrapped in a `<strong>` element, etc).