### PR TITLE
Change wrapping of file path in "Download Succeeded" Modal

### DIFF
--- a/js/component/link.js
+++ b/js/component/link.js
@@ -135,8 +135,9 @@ var DownloadLink = React.createClass({
       <span className="button-container">
         <Link button={this.props.button} hidden={this.props.hidden} style={this.props.style}
               disabled={this.state.downloading} label={label} icon={this.props.icon} onClick={this.handleClick} />
-        <Modal isOpen={this.state.modal == 'downloadStarted'} onConfirmed={this.closeModal}>
-          Downloading to {this.state.filePath}
+        <Modal className="download-started-modal" isOpen={this.state.modal == 'downloadStarted'} onConfirmed={this.closeModal}>
+          <p>Downloading to:</p>
+          <div className="download-started-modal__file-path">{this.state.filePath}</div>
         </Modal>
         <Modal isOpen={this.state.modal == 'notEnoughCredits'} onConfirmed={this.closeModal}>
           You don't have enough LBRY credits to pay for this stream.

--- a/scss/_gui.scss
+++ b/scss/_gui.scss
@@ -352,3 +352,7 @@ input[type="text"], input[type="search"]
   margin-top: 6px;
   margin-right: 7px;
 }
+
+.download-started-modal__file-path {
+  word-break: break-all;
+}


### PR DESCRIPTION
This displays the file path on its own line and does character-level wrapping on the path only.

Ideally, we would just apply character wrapping to all words that are too long to fit on one line, and use normal word wrapping for everything else. There are CSS props for this like `overflow-wrap` and `word-break`, but I haven't been able to find a way to do it cross-browser without setting a width on the outer container, which we don't want here (modals stretch based on their content). So this is the best compromise I could come up with. 

Fixes this issue: https://app.asana.com/0/search/223675889679358/215539621304348
