### PR TITLE
Import MediaElement with <script> tag

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -20,6 +20,8 @@
     </head>
     <body>
       <div id="canvas"></div>
+      <script src="./js/mediaelement/jquery.js"></script>
+      <script src="./js/mediaelement/mediaelement-and-player.min.js"></script>
       <script src="./js/bundle.js"></script>
     </body>
 </html>

--- a/js/page/watch.js
+++ b/js/page/watch.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import lbry from '../lbry.js';
 import LoadScreen from '../component/load_screen.js'
-import MediaElementPlayer from 'mediaelement';
-
 
 var WatchPage = React.createClass({
   propTypes: {


### PR DESCRIPTION
Needed because MediaElement doesn't fully support ES6 modules yet