### PR TITLE
Fix search on pages other than Discover

### DIFF
--- a/js/page/discover.js
+++ b/js/page/discover.js
@@ -292,7 +292,7 @@ var DiscoverPage = React.createClass({
     document.title = "Discover";
     if (this.props.query) {
       // Rendering with a query already typed
-      this.handleSearchChanged();
+      this.handleSearchChanged(this.props.query);
     }
   },
 


### PR DESCRIPTION
Before, searches from other pages were sending "null" to lighthouse instead of the query.

Fixes this issue: https://app.asana.com/0/114030215896582/237763457319371