### PR TITLE
Bypass check for Flash being installed in MediaElement.js

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -21,7 +21,7 @@
     <body>
       <div id="canvas"></div>
       <script src="./js/mediaelement/jquery.js"></script>
-      <script src="./js/mediaelement/mediaelement-and-player.min.js"></script>
+      <script src="./js/mediaelement/mediaelement-and-player.js"></script>
       <script src="./js/bundle.js"></script>
     </body>
 </html>

--- a/dist/js/mediaelement/mediaelement-and-player.js
+++ b/dist/js/mediaelement/mediaelement-and-player.js
@@ -309,6 +309,16 @@ mejs.PluginDetector = {
 
 	// main public function to test a plug version number PluginDetector.hasPluginVersion('flash',[9,0,125]);
 	hasPluginVersion: function(plugin, v) {
+		/**
+		 * Workaround for LBRY: Safari now reports Flash being disabled even when it's installed.
+		 * So we have to pretend we know it's installed. (This also makes sure that users of all
+		 * browsers get a "missing plugin" message if they don't have Flash installed.)
+		 */
+
+		if (plugin == 'flash') {
+			return true;
+		}
+
 		var pv = this.plugins[plugin];
 		v[1] = v[1] || 0;
 		v[2] = v[2] || 0;

--- a/js/page/watch.js
+++ b/js/page/watch.js
@@ -34,7 +34,7 @@ var WatchPage = React.createClass({
           mimeType: status.mime_type,
         })
         var player = new MediaElementPlayer(this.refs.player, {
-          mode: 'auto_plugin',
+          mode: 'shim',
           plugins: ['flash'],
           setDimensions: false,
         });


### PR DESCRIPTION
Needed because Safari now reports that Flash isn't installed, even when it is: https://webkit.org/blog/6589/next-steps-for-legacy-plug-ins/