### PR TITLE
Don't time out on Publish page

### DIFF
--- a/js/lbry.js
+++ b/js/lbry.js
@@ -306,10 +306,10 @@ lbry.getFileInfoWhenListed = function(name, callback, timeoutCallback, tryNum=0)
       }
     }
 
-    if (tryNum <= 200) {
-      setTimeout(function() { lbry.getFileInfoWhenListed(name, callback, timeoutCallback, tryNum + 1) }, 250);
-    } else if (timeoutCallback) {
+    if (timeoutCallback && tryNum > 200) {
       timeoutCallback();
+    } else {
+      setTimeout(function() { lbry.getFileInfoWhenListed(name, callback, timeoutCallback, tryNum + 1) }, 250);
     }
   });
 }


### PR DESCRIPTION
lbry.getFileInfoWhenListed() now only times out if a timeout callback is provided.