### PR TITLE
Fix status check on Watch page

### DIFF
--- a/js/page/watch.js
+++ b/js/page/watch.js
@@ -20,7 +20,7 @@ var WatchPage = React.createClass({
   },
   updateLoadStatus: function() {
     lbry.getFileStatus(this.props.name, (status) => {
-      if (!status || status.code != 'running' || status.written_bytes == 0) {
+      if (!status || ['running', 'stopped'].includes(status.code) || status.written_bytes == 0) {
         // Download hasn't started yet, so update status message (if available) then try again
         if (status) {
           this.setState({


### PR DESCRIPTION
Before, it wouldn't recognize "stopped" status as a playable state.