### PR TITLE
Re-integrate Back button on Watch page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Web UI version numbers should always match the corresponding version of LBRY App
 
 ## [Unreleased]
 ### Added
-  *
+  * "Back to LBRY" button on Watch page
   *
   *
 

--- a/js/page/watch.js
+++ b/js/page/watch.js
@@ -52,7 +52,7 @@ var WatchPage = React.createClass({
       });
     }, this._controlsHideDelay);
   },
-  handleMouseOut: function() {
+  handleMouseLeave: function() {
     if (this._controlsTimeout) {
       clearTimeout(this._controlsTimeout);
     }
@@ -97,7 +97,7 @@ var WatchPage = React.createClass({
     return (
       !this.state.readyToPlay
         ? <LoadScreen message={'Loading video...'} details={this.state.loadStatusMessage} />
-        : <main className="video full-screen" onMouseMove={this.handleMouseMove} onMouseOut={this.handleMouseOut}>
+        : <main className="video full-screen" onMouseMove={this.handleMouseMove} onMouseLeave={this.handleMouseLeave}>
             <video controls width="100%" height="100%" id="video" ref="video"></video>
             {this.state.controlsShown
               ? <div className="video__overlay">

--- a/js/page/watch.js
+++ b/js/page/watch.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import {Icon} from '../component/common.js';
+import {Link} from '../component/link.js';
 import lbry from '../lbry.js';
 import LoadScreen from '../component/load_screen.js'
 
@@ -21,6 +23,9 @@ var WatchPage = React.createClass({
   componentDidMount: function() {
     lbry.getStream(this.props.name);
     this.updateLoadStatus();
+  },
+  handleBackClicked: function() {
+    history.back();
   },
   updateLoadStatus: function() {
     lbry.getFileStatus(this.props.name, (status) => {
@@ -56,9 +61,19 @@ var WatchPage = React.createClass({
     return (
       !this.state.readyToPlay
         ? <LoadScreen message={'Loading video...'} details={this.state.loadStatusMessage} />
-        : <main className="full-screen">
-            <video controls width="100%" height="100%" id="video" ref="video">
-            </video>
+        : <main className="video full-screen">
+            <video controls width="100%" height="100%" id="video" ref="video"></video>
+            <div className="video__overlay">
+              <div className="video__back">
+                <Link icon="icon-arrow-circle-o-left" className="video__back-link" onClick={this.handleBackClicked}/>
+                <div className="video__back-label">
+                  <Icon icon="icon-caret-left" className="video__back-label-arrow" />
+                  <div className="video__back-label-content">
+                    Back to LBRY
+                  </div>
+                </div>
+              </div>
+            </div>
           </main>
     );
   }

--- a/js/page/watch.js
+++ b/js/page/watch.js
@@ -9,6 +9,10 @@ const VideoStream = require('videostream');
 
 
 var WatchPage = React.createClass({
+  _isMounted: false,
+  _controlsHideDelay: 3000, // Note: this needs to be shorter than the built-in delay in Electron, or Electron will hide the controls before us
+  _controlsHideTimeout: null,
+
   propTypes: {
     name: React.PropTypes.string,
   },
@@ -18,6 +22,7 @@ var WatchPage = React.createClass({
       readyToPlay: false,
       loadStatusMessage: "Requesting stream",
       mimeType: null,
+      controlsShown: false,
     };
   },
   componentDidMount: function() {
@@ -26,6 +31,37 @@ var WatchPage = React.createClass({
   },
   handleBackClicked: function() {
     history.back();
+  },
+  handleMouseMove: function() {
+    if (this._controlsTimeout) {
+      clearTimeout(this._controlsTimeout);
+    }
+
+    if (!this.state.controlsShown) {
+      this.setState({
+        controlsShown: true,
+      });
+    }
+    this._controlsTimeout = setTimeout(() => {
+      if (!this.isMounted) {
+        return;
+      }
+
+      this.setState({
+        controlsShown: false,
+      });
+    }, this._controlsHideDelay);
+  },
+  handleMouseOut: function() {
+    if (this._controlsTimeout) {
+      clearTimeout(this._controlsTimeout);
+    }
+
+    if (this.state.controlsShown) {
+      this.setState({
+        controlsShown: false,
+      });
+    }
   },
   updateLoadStatus: function() {
     lbry.getFileStatus(this.props.name, (status) => {
@@ -61,19 +97,21 @@ var WatchPage = React.createClass({
     return (
       !this.state.readyToPlay
         ? <LoadScreen message={'Loading video...'} details={this.state.loadStatusMessage} />
-        : <main className="video full-screen">
+        : <main className="video full-screen" onMouseMove={this.handleMouseMove} onMouseOut={this.handleMouseOut}>
             <video controls width="100%" height="100%" id="video" ref="video"></video>
-            <div className="video__overlay">
-              <div className="video__back">
-                <Link icon="icon-arrow-circle-o-left" className="video__back-link" onClick={this.handleBackClicked}/>
-                <div className="video__back-label">
-                  <Icon icon="icon-caret-left" className="video__back-label-arrow" />
-                  <div className="video__back-label-content">
-                    Back to LBRY
+            {this.state.controlsShown
+              ? <div className="video__overlay">
+                  <div className="video__back">
+                    <Link icon="icon-arrow-circle-o-left" className="video__back-link" onClick={this.handleBackClicked}/>
+                    <div className="video__back-label">
+                      <Icon icon="icon-caret-left" className="video__back-label-arrow" />
+                      <div className="video__back-label-content">
+                        Back to LBRY
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </div>
+              : null}
           </main>
     );
   }

--- a/scss/all.scss
+++ b/scss/all.scss
@@ -11,3 +11,4 @@
 @import "component/_tooltip.scss";
 @import "component/_load-screen.scss";
 @import "page/_developer.scss";
+@import "page/_watch.scss";

--- a/scss/page/_watch.scss
+++ b/scss/page/_watch.scss
@@ -5,9 +5,7 @@
 .video__overlay {
   position: absolute;
   top: 0px;
-  bottom: 0px;
   left: 0px;
-  right: 0px;
   color: #fff;
   z-index: 1;
 }

--- a/scss/page/_watch.scss
+++ b/scss/page/_watch.scss
@@ -1,0 +1,50 @@
+.video {
+  background: #000;
+}
+
+.video__overlay {
+  position: absolute;
+  top: 0px;
+  bottom: 0px;
+  left: 0px;
+  right: 0px;
+  color: #fff;
+  z-index: 1;
+}
+
+.video__back {
+  margin-top: 30px;
+  margin-left: 50px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.video__back-link {
+  font-size: 50px;
+}
+
+.video__back-label {
+  opacity: 0;
+  transition: opacity 100ms ease-in;
+}
+
+.video__back-link:hover + .video__back-label {
+  opacity: 1;
+}
+
+.video__back-label-arrow {
+  color: darken($color-primary, 5%);
+  font-size: 20px;
+}
+
+.video__back-label-content {
+  display: inline-block;
+  margin-left: -2px;
+  font-size: 20px;
+  padding: 10px;
+  border-radius: 3px;
+  background-color: darken($color-primary, 5%);
+  color: #fff;
+  pointer-events: none;
+}

--- a/scss/page/_watch.scss
+++ b/scss/page/_watch.scss
@@ -33,18 +33,21 @@
   opacity: 1;
 }
 
+$video-back-background: #333;
+$video-back-size: 20px;
+
 .video__back-label-arrow {
-  color: darken($color-primary, 5%);
-  font-size: 20px;
+  color: $video-back-background;
+  font-size: $video-back-size;
 }
 
 .video__back-label-content {
   display: inline-block;
   margin-left: -2px;
-  font-size: 20px;
-  padding: 10px;
+  font-size: $video-back-size;
+  padding: $spacing-vertical / 2;
   border-radius: 3px;
-  background-color: darken($color-primary, 5%);
+  background-color: $video-back-background;
   color: #fff;
   pointer-events: none;
 }


### PR DESCRIPTION
Add the Back button back to the Watch page. It was previously lost in a tragic merging incident. Also added a changelog entry and fixed a bug causing the button to flicker when you move the mouse over it.