### PR TITLE
On load screen, always show Cancel link if a previous page is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Web UI version numbers should always match the corresponding version of LBRY App
   *
 
 ### Fixed
-  *
+  * On load screen, always show Cancel link if a previous page is available
   *
   *
 

--- a/js/component/load_screen.js
+++ b/js/component/load_screen.js
@@ -34,7 +34,7 @@ var LoadScreen = React.createClass({
             <BusyMessage message={this.props.message} />
           </h3>
           {this.props.isWarning ? <Icon icon="icon-warning" /> : null} <span className={'load-screen__details ' + (this.props.isWarning ? 'load-screen__details--warning' : '')}>{this.props.details}</span>
-          {this.props.isWarning
+          {window.history.length > 1
             ? <div><Link label="Cancel" onClick={this.handleCancelClick} className='load-screen__cancel-link button-text' /></div>
             : null}
         </div>


### PR DESCRIPTION
Before, it was only showing if a load attempt timed out, and would show even if there was no previous page to go back to.