### PR TITLE
Revamp API wrapper code (WIP)

### DIFF
--- a/js/jsonrpc.js
+++ b/js/jsonrpc.js
@@ -1,0 +1,69 @@
+const jsonrpc = {};
+
+jsonrpc.call = function (connectionString, method, params, callback, errorCallback, connectFailedCallback, timeout) {
+  var xhr = new XMLHttpRequest;
+  if (typeof connectFailedCallback !== 'undefined') {
+    if (timeout) {
+      xhr.timeout = timeout;
+    }
+
+    xhr.addEventListener('error', function (e) {
+      connectFailedCallback(e);
+    });
+    xhr.addEventListener('timeout', function() {
+      connectFailedCallback(new Error('XMLHttpRequest connection timed out'));
+    })
+  }
+  xhr.addEventListener('load', function() {
+    var response = JSON.parse(xhr.responseText);
+
+    if (response.error) {
+      if (errorCallback) {
+        errorCallback(response.error);
+      } else {
+        var errorEvent = new CustomEvent('unhandledError', {
+          detail: {
+            connectionString: connectionString,
+            method: method,
+            params: params,
+            code: response.error.code,
+            message: response.error.message,
+            data: response.error.data
+          }
+        });
+        document.dispatchEvent(errorEvent)
+      }
+    } else if (callback) {
+      callback(response.result);
+    }
+  });
+
+  if (connectFailedCallback) {
+    xhr.addEventListener('error', function (event) {
+      connectFailedCallback(event);
+    });
+  } else {
+    xhr.addEventListener('error', function (event) {
+      var errorEvent = new CustomEvent('unhandledError', {
+        detail: {
+          connectionString: connectionString,
+          method: method,
+          params: params,
+          code: xhr.status,
+          message: 'Connection to API server failed'
+        }
+      });
+      document.dispatchEvent(errorEvent);
+    });
+  }
+
+  xhr.open('POST', connectionString, true);
+  xhr.send(JSON.stringify({
+    'jsonrpc': '2.0',
+    'method': method,
+    'params': params,
+    'id': 0
+  }));
+};
+
+export default jsonrpc;

--- a/js/jsonrpc.js
+++ b/js/jsonrpc.js
@@ -57,13 +57,17 @@ jsonrpc.call = function (connectionString, method, params, callback, errorCallba
     });
   }
 
+  const counter = parseInt(sessionStorage.getItem('JSONRPCCounter') || 0);
+
   xhr.open('POST', connectionString, true);
   xhr.send(JSON.stringify({
     'jsonrpc': '2.0',
     'method': method,
     'params': params,
-    'id': 0
+    'id': counter,
   }));
+
+  sessionStorage.setItem('JSONRPCCounter', counter + 1);
 };
 
 export default jsonrpc;

--- a/js/lbry.js
+++ b/js/lbry.js
@@ -1,6 +1,8 @@
 import lighthouse from './lighthouse.js';
+import lbrynet from './lbrynet.js';
+import jsonrpc from './jsonrpc.js';
 
-var lbry = {
+const lbry = {
   isConnected: false,
   rootPath: '.',
   daemonConnectionString: 'http://localhost:5279/lbryapi',
@@ -18,74 +20,8 @@ var lbry = {
   }
 };
 
-lbry.jsonrpc_call = function (connectionString, method, params, callback, errorCallback, connectFailedCallback, timeout) {
-  var xhr = new XMLHttpRequest;
-  if (typeof connectFailedCallback !== 'undefined') {
-    if (timeout) {
-      xhr.timeout = timeout;
-    }
-
-    xhr.addEventListener('error', function (e) {
-      connectFailedCallback(e);
-    });
-    xhr.addEventListener('timeout', function() {
-      connectFailedCallback(new Error('XMLHttpRequest connection timed out'));
-    })
-  }
-  xhr.addEventListener('load', function() {
-    var response = JSON.parse(xhr.responseText);
-
-    if (response.error) {
-      if (errorCallback) {
-        errorCallback(response.error);
-      } else {
-        var errorEvent = new CustomEvent('unhandledError', {
-          detail: {
-            connectionString: connectionString,
-            method: method,
-            params: params,
-            code: response.error.code,
-            message: response.error.message,
-            data: response.error.data
-          }
-        });
-        document.dispatchEvent(errorEvent)
-      }
-    } else if (callback) {
-      callback(response.result);
-    }
-  });
-
-  if (connectFailedCallback) {
-    xhr.addEventListener('error', function (event) {
-      connectFailedCallback(event);
-    });
-  } else {
-    xhr.addEventListener('error', function (event) {
-      var errorEvent = new CustomEvent('unhandledError', {
-        detail: {
-          connectionString: connectionString,
-          method: method,
-          params: params,
-          code: xhr.status,
-          message: 'Connection to API server failed'
-        }
-      });
-      document.dispatchEvent(errorEvent);
-    });
-  }
-
-  xhr.open('POST', connectionString, true);
-  xhr.send(JSON.stringify({
-    'jsonrpc': '2.0',
-    'method': method,
-    'params': params,
-    'id': 0
-  }));
-}
-
 lbry.call = function (method, params, callback, errorCallback, connectFailedCallback) {
-  lbry.jsonrpc_call(lbry.daemonConnectionString, method, [params], callback, errorCallback, connectFailedCallback);
+  jsonrpc.call(lbry.daemonConnectionString, method, [params], callback, errorCallback, connectFailedCallback);
 }
 
 
@@ -240,10 +176,8 @@ lbry.getCostInfoForName = function(name, callback, errorCallback) {
     }, errorCallback);
   }
 
-  lighthouse.getSizeForName(name, (size) => {
+  lighthouse.get_size_for_name(name).then((size) => {
     getCostWithData(name, size, callback, errorCallback);
-  }, () => {
-    getCostNoData(name, callback, errorCallback);
   }, () => {
     getCostNoData(name, callback, errorCallback);
   });
@@ -333,7 +267,7 @@ lbry.getFileInfoWhenListed = function(name, callback, timeoutCallback, tryNum=0)
 
   // Calls callback with file info when it appears in the lbrynet file manager.
   // If timeoutCallback is provided, it will be called if the file fails to appear.
-  lbry.getFileStatus(name, (fileInfo) => {
+  lbrynet.file_list({name: name}).then(([fileInfo]) => {
     if (fileInfo) {
       callback(fileInfo);
     } else {

--- a/js/lbrynet.js
+++ b/js/lbrynet.js
@@ -1,0 +1,15 @@
+import jsonrpc from './jsonrpc.js';
+
+const connectionString = 'http://localhost:5279/lbryapi';
+
+const lbrynet = new Proxy({}, {
+  get: function(target, name) {
+    return function(params={}) {
+      return new Promise((resolve, reject) => {
+        jsonrpc.call(connectionString, name, [params], resolve, reject, reject);
+      });
+    };
+  },
+});
+
+export default lbrynet;

--- a/js/lighthouse.js
+++ b/js/lighthouse.js
@@ -1,67 +1,64 @@
 import lbry from './lbry.js';
+import jsonrpc from './jsonrpc.js';
 
-var lighthouse = {
-  _query_timeout: 5000,
-  _max_query_tries: 5,
+const queryTimeout = 5000;
+const maxQueryTries = 5;
+const defaultServers = [
+  'http://lighthouse4.lbry.io:50005',
+  'http://lighthouse5.lbry.io:50005',
+  'http://lighthouse6.lbry.io:50005',
+];
+const path = '/';
 
-  servers: [
-    'http://lighthouse4.lbry.io:50005',
-    'http://lighthouse5.lbry.io:50005',
-    'http://lighthouse6.lbry.io:50005',
-  ],
-  path: '/',
+let server = null;
+let connectTryNum = 0;
 
-  call: function(method, params, callback, errorCallback, connectFailedCallback, timeout) {
-    const handleConnectFailed = function(tryNum=0) {
-      if (tryNum > lighthouse._max_query_tries) {
-        if (connectFailedCallback) {
-          connectFailedCallback();
-        } else {
-          throw new Error(`Could not connect to Lighthouse server. Last server attempted: ${lighthouse.server}`);
-        }
-      } else {
-        lbry.call(method, params, callback, errorCallback, () => { handleConnectFailed(tryNum + 1) }, timeout);
-      }
-    }
+function getServers() {
+  return lbry.getClientSetting('useCustomLighthouseServers')
+    ? lbry.getClientSetting('customLighthouseServers')
+    : defaultServers;
+}
 
-    // Set the Lighthouse server if it hasn't been set yet, or if the current server is not in
-    // the current set of servers (most likely because of a settings change).
-    if (typeof lighthouse.server === 'undefined' || lighthouse.getServers().indexOf(lighthouse.server) == -1) {
-      lighthouse.chooseNewServer();
-    }
-
-    lbry.jsonrpc_call(this.server + this.path, method, params, callback, errorCallback,
-                      () => { handleConnectFailed() }, timeout || lighthouse.query_timeout);
-  },
-
-  getServers: function() {
-    return lbry.getClientSetting('useCustomLighthouseServers')
-      ? lbry.getClientSetting('customLighthouseServers')
-      : lighthouse.servers;
-  },
-
-  chooseNewServer: function() {
-    // Randomly choose a new Lighthouse server and switch to it. If a server is already set, this
-    // will choose a different one (used for switching servers after a failed query).
-    const servers = lighthouse.getServers();
-    let newServerChoices;
-    if (!lighthouse.server) {
-      newServerChoices = servers;
+function call(method, params, callback, errorCallback) {
+  if (connectTryNum > maxQueryTries) {
+    if (connectFailedCallback) {
+      connectFailedCallback();
     } else {
-      newServerChoices = lighthouse.getServers().slice();
-      newServerChoices.splice(newServerChoices.indexOf(lighthouse.server), 1);
+      throw new Error(`Could not connect to Lighthouse server. Last server attempted: ${server}`);
     }
-    lighthouse.server = newServerChoices[Math.round(Math.random() * (newServerChoices.length - 1))];
-  },
-
-  search: function(query, callback, errorCallback, connectFailedCallback, timeout) {
-    lighthouse.call('search', [query], callback, errorCallback, connectFailedCallback, timeout);
-  },
-
-  getSizeForName: function(name, callback, errorCallback, connectFailedCallback, timeout) {
-    lighthouse.call('get_size_for_name', [name], callback, errorCallback, connectFailedCallback, timeout);
   }
-};
 
+  /**
+   * Set the Lighthouse server if it hasn't been set yet, if the current server is not in current
+   * set of servers (most likely because of a settings change), or we're re-trying after a failed
+   * query.
+   */
+  if (!server || !getServers().includes(server) || connectTryNum > 0) {
+    // If there's a current server, filter it out so we get a new one
+    const newServerChoices = server ? getServers().filter((s) => s != server) : getServers();
+    server = newServerChoices[Math.round(Math.random() * (newServerChoices.length - 1))];
+  }
+
+  jsonrpc.call(server + path, method, params, (response) => {
+    connectTryNum = 0;
+    callback(response);
+  }, (error) => {
+    connectTryNum = 0;
+    errorCallback(error);
+  }, () => {
+    connectTryNum++;
+    call(method, params, callback, errorCallback);
+  });
+}
+
+const lighthouse = new Proxy({}, {
+  get: function(target, name) {
+    return function(...params) {
+      return new Promise((resolve, reject) => {
+        call(name, params, resolve, reject);
+      });
+    };
+  },
+});
 
 export default lighthouse;

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import lbry from './lbry.js';
+import lbrynet from './lbrynet.js';
 import lighthouse from './lighthouse.js';
 import App from './app.js';
 import SplashScreen from './component/splash.js';
@@ -8,9 +9,8 @@ import SplashScreen from './component/splash.js';
 
 var init = function() {
   window.lbry = lbry;
-  if (lbry.getClientSetting('debug')) {
-    window.lighthouse = lighthouse;
-  }
+  window.lighthouse = lighthouse;
+  window.lbrynet = lbrynet;
 
   var canvas = document.getElementById('canvas');
   if (window.sessionStorage.getItem('loaded') == 'y') {

--- a/js/page/discover.js
+++ b/js/page/discover.js
@@ -125,7 +125,7 @@ var DiscoverPage = React.createClass({
       query: query,
     });
 
-    lighthouse.search(query, this.searchCallback);
+    lighthouse.search(query).then(this.searchCallback);
   },
 
   componentWillMount: function() {


### PR DESCRIPTION
 - Refactoring throughout JSON-RPC, lbrynet and Lighthouse logic
 - Move JSON-RPC stuff into its own module
 - Create new lbrynet module that dynamically generates API RPC calls based on the name of the function called. Also uses promises instead of callbacks.
 - Convert lighthouse module to work the same way.
 - Converted some lbrynet calls and all Lighthouse calls to use the new style
 - Add unique ID to all JSON-RPC calls